### PR TITLE
Added typically used discord structs and a SendMessage abstraction 

### DIFF
--- a/Examples/stupidBot.md
+++ b/Examples/stupidBot.md
@@ -6,7 +6,7 @@ This is all the code required to create a bot that has no commands, hooks, servi
 package main
 
 import (
-    "github.com/andersfylling/unison"
+    "github.com/s1kx/unison"
     "github.com/sirupsen/logrus"
 )
 

--- a/bot.go
+++ b/bot.go
@@ -283,9 +283,14 @@ func (bot *Bot) SetGuildValue(guildID, key string, val []byte) error {
 }
 
 // SendMessage sends a string message to a given channel
-func (bot *Bot) SendMessage(channel *discord.Channel, msg string) {
+func (bot *Bot) SendMessage(channel *discord.Channel, msg string) (*discord.Message, error) {
 	// TODO maybe add this a discord.Channel method, but need to store discord session when creating object
-	bot.Discord.ChannelMessageSend(channel.IDToStr(), msg)
+	discordgoMessage, err := bot.Discord.ChannelMessageSend(channel.IDToStr(), msg)
+	if err != nil {
+		return nil, err
+	}
+
+	return discord.NewMessageFromDiscordgo(discordgoMessage)
 }
 
 // Event listeners

--- a/bot.go
+++ b/bot.go
@@ -290,7 +290,7 @@ func (bot *Bot) SendMessage(channel *discord.Channel, msg string) (*discord.Mess
 		return nil, err
 	}
 
-	return discord.NewMessageFromDiscordgo(discordgoMessage), nil
+	return discord.NewMessageFromDgo(discordgoMessage), nil
 }
 
 // Event listeners

--- a/bot.go
+++ b/bot.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/s1kx/unison/discord"
 	"github.com/s1kx/unison/state"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/bwmarrin/Discordgo.v0"
@@ -279,6 +280,12 @@ func (bot *Bot) SetGuildValue(guildID, key string, val []byte) error {
 		return errors.New("bolt(key-value) database has been disabled in config struct")
 	}
 	return state.SetGuildValue(guildID, key, val)
+}
+
+// SendMessage sends a string message to a given channel
+func (bot *Bot) SendMessage(channel *discord.Channel, msg string) {
+	// TODO maybe add this a discord.Channel method, but need to store discord session when creating object
+	bot.Discord.ChannelMessageSend(channel.IDToStr(), msg)
 }
 
 // Event listeners

--- a/bot.go
+++ b/bot.go
@@ -290,7 +290,7 @@ func (bot *Bot) SendMessage(channel *discord.Channel, msg string) (*discord.Mess
 		return nil, err
 	}
 
-	return discord.NewMessageFromDiscordgo(discordgoMessage)
+	return discord.NewMessageFromDiscordgo(discordgoMessage), nil
 }
 
 // Event listeners

--- a/discord/attachment.go
+++ b/discord/attachment.go
@@ -1,5 +1,9 @@
 package discord
 
+import (
+	"gopkg.in/bwmarrin/Discordgo.v0"
+)
+
 type Attachment struct {
 	ID       uint64 `json:"id"`
 	Filename string `json:"filename"`
@@ -8,4 +12,16 @@ type Attachment struct {
 	ProxyURL string `json:"proxy_url"`
 	Height   uint   `json:"height"`
 	Width    uint   `json:"width"`
+}
+
+func NewAttachmentFromDiscordgo(a *discordgo.MessageAttachment) *Attachment {
+	return &Attachment{
+		ID:       discordgoIDStringToUint64(a.ID),
+		Filename: a.Filename,
+		Size:     uint(a.Size),
+		URL:      a.URL,
+		ProxyURL: a.ProxyURL,
+		Height:   uint(a.Height),
+		Width:    uint(a.Width),
+	}
 }

--- a/discord/attachment.go
+++ b/discord/attachment.go
@@ -1,9 +1,5 @@
 package discord
 
-import (
-	"gopkg.in/bwmarrin/Discordgo.v0"
-)
-
 type Attachment struct {
 	ID       uint64 `json:"id"`
 	Filename string `json:"filename"`
@@ -12,16 +8,4 @@ type Attachment struct {
 	ProxyURL string `json:"proxy_url"`
 	Height   uint   `json:"height"`
 	Width    uint   `json:"width"`
-}
-
-func NewAttachmentFromDiscordgo(a *discordgo.MessageAttachment) *Attachment {
-	return &Attachment{
-		ID:       discordgoIDStringToUint64(a.ID),
-		Filename: a.Filename,
-		Size:     uint(a.Size),
-		URL:      a.URL,
-		ProxyURL: a.ProxyURL,
-		Height:   uint(a.Height),
-		Width:    uint(a.Width),
-	}
 }

--- a/discord/auditlog.go
+++ b/discord/auditlog.go
@@ -21,7 +21,7 @@ type AuditLogEntry struct {
 	TargetID   uint64            `json:"target_id"`
 	UserID     uint64            `json:"user_id"`
 	ID         uint64            `json:"id"`
-	ActionType uint8             `json:"action_type"`
+	ActionType uint              `json:"action_type"`
 	Changes    []*AuditLogChange `json:"changes"`
 	Options    []*AuditLogOption `json:"options"`
 	Reason     string            `json:"reason"`
@@ -36,7 +36,7 @@ type AuditLog struct {
 // AuditLogParams set params used in endpoint request
 type AuditLogParams struct {
 	UserID     uint64 `urlparam:"user_id,omitempty"`
-	ActionType uint8  `urlparam:"action_type,omitempty"`
+	ActionType uint   `urlparam:"action_type,omitempty"`
 	Before     uint64 `urlparam:"before,omitempty"`
 	Limit      int    `urlparam:"limit,omitempty"`
 }

--- a/discord/channel.go
+++ b/discord/channel.go
@@ -19,8 +19,12 @@ type Channel struct {
 	PermissionOverwrites []*PermissionOverwrite `json:"permission_overwrites"`
 }
 
-func New() *Channel {
+func NewChannel() *Channel {
 	return &Channel{}
+}
+
+func (c *Channel) IDToStr() string {
+	return uint64ToString(c.ID)
 }
 
 func (c *Channel) Mention() string {

--- a/discord/channel.go
+++ b/discord/channel.go
@@ -9,7 +9,7 @@ type Channel struct {
 	GuildID              uint64                 `json:"guild_id"`
 	Name                 string                 `json:"name"`
 	Topic                string                 `json:"topic"`
-	Type                 uint8                  `json:"type"`
+	Type                 uint                   `json:"type"`
 	LastMessageID        uint64                 `json:"last_message_id"`
 	NSFW                 bool                   `json:"nsfw"`
 	Position             uint                   `json:"position"`

--- a/discord/discordgoconv.go
+++ b/discord/discordgoconv.go
@@ -1,8 +1,15 @@
 package discord
 
-import "strconv"
+import (
+	"strconv"
+	"time"
 
-func discordIDStringToUint64(id string) uint64 {
+	"gopkg.in/bwmarrin/Discordgo.v0"
+)
+
+const discordgoTimestampLayout string = "2016-08-06T17:20:33.803-0400"
+
+func discordgoIDStringToUint64(id string) uint64 {
 	if id == "" {
 		return 0
 	}
@@ -17,4 +24,27 @@ func discordIDStringToUint64(id string) uint64 {
 
 func uint64ToString(id uint64) string {
 	return strconv.FormatUint(id, 10)
+}
+
+func discordgoTimestampToTime(ts string) time.Time {
+	timestamp, err := time.Parse(discordgoTimestampLayout, ts)
+	if err != nil {
+		panic(err)
+		//return time.Now() // this is so bad..
+	}
+
+	return timestamp
+}
+
+func discordgoUserArrayTODiscordUserArray(users []*discordgo.User) []*User {
+	discordUsers := make([]*User, 0, len(users))
+	for i, user := range users {
+		discordUsers[i] = NewUserFromDiscordgo(user)
+	}
+
+	return discordUsers
+}
+
+func discordgoCopyTodiscordStruct(discordgoStruct interface{}, discordStruct interface{}) {
+	// TODO use reflection to copy over values with similar type and json tag.
 }

--- a/discord/discordgoconv.go
+++ b/discord/discordgoconv.go
@@ -221,7 +221,16 @@ func NewMessageFromDiscordgo(msg *discordgo.Message) *Message {
 }
 
 func NewRoleFromDiscordgo(r *discordgo.Role) *Role {
-	return &Role{}
+	return &Role{
+		ID:          discordgoIDStringToUint64(r.ID),
+		Name:        r.Name,
+		Managed:     r.Managed,
+		Mentionable: r.Mentionable,
+		Hoist:       r.Hoist,
+		Color:       r.Color,
+		Position:    r.Position,
+		Permissions: uint64(r.Permissions),
+	}
 	// TODO
 }
 

--- a/discord/discordgoconv.go
+++ b/discord/discordgoconv.go
@@ -136,6 +136,10 @@ func discordgoVerificationLevelToUint8(vl discordgo.VerificationLevel) uint8 {
 	return uint8(vl)
 }
 
+func discordgoStatusToString(s discordgo.Status) string {
+	return string(s)
+}
+
 // Struct converters
 //
 
@@ -257,8 +261,13 @@ func NewGuildMemberFromDiscordgo(m *discordgo.Member) *GuildMember {
 }
 
 func NewPresenceFromDiscordgo(p *discordgo.Presence) *Presence {
-	return &Presence{}
-	// TODO
+	return &Presence{
+		User:  NewUserFromDiscordgo(p.User),
+		Roles: discordgoIDStringArrayToUint64Array(p.Roles),
+		// Game: NewActivityFromDiscordgo(p.Activity), // not implemented by discordgo...
+		// GuildID: discordgoIDStringToUint64(p.GuildID), // not implemented by discordgo..
+		Status: discordgoStatusToString(p.Status),
+	}
 }
 
 func NewChannelFromDiscordgo(c *discordgo.Channel) *Channel {

--- a/discord/discordgoconv.go
+++ b/discord/discordgoconv.go
@@ -7,12 +7,12 @@ import (
 	"gopkg.in/bwmarrin/Discordgo.v0"
 )
 
-const discordgoTimestampLayout string = "2016-08-06T17:20:33.803-0400"
+const dgoTimestampLayout string = "2016-08-06T17:20:33.803-0400" // Needs checking
 
 // Small purpose specific functionality
 //
 
-func discordgoIDStringToUint64(id string) uint64 {
+func dgoIDStringToUint64(id string) uint64 {
 	if id == "" {
 		return 0
 	}
@@ -25,10 +25,10 @@ func discordgoIDStringToUint64(id string) uint64 {
 	return u
 }
 
-func discordgoIDStringArrayToUint64Array(ids []string) []uint64 {
+func dgoIDStringsToUint64s(ids []string) []uint64 {
 	newIDS := make([]uint64, 0, len(ids))
 	for i, id := range ids {
-		newIDS[i] = discordgoIDStringToUint64(id)
+		newIDS[i] = dgoIDStringToUint64(id)
 	}
 
 	return newIDS
@@ -38,21 +38,21 @@ func uint64ToString(id uint64) string {
 	return strconv.FormatUint(id, 10)
 }
 
-func discordgoAttachmentArrayToDiscordAttachmentArray(as []*discordgo.MessageAttachment) []*Attachment {
+func dgoAttachmentsToDiscordAttachments(as []*discordgo.MessageAttachment) []*Attachment {
 	attachments := make([]*Attachment, 0, len(as))
 	for i, a := range as {
-		attachments[i] = NewAttachmentFromDiscordgo(a)
+		attachments[i] = NewAttachmentFromDgo(a)
 	}
 
 	return attachments
 }
 
-func discordgoTimestampToTime(ts discordgo.Timestamp) time.Time {
-	return discordgoTimestampStringToTime(string(ts))
+func dgoTimestampToTime(ts discordgo.Timestamp) time.Time {
+	return dgoTimestampStringToTime(string(ts))
 }
 
-func discordgoTimestampStringToTime(ts string) time.Time {
-	timestamp, err := time.Parse(discordgoTimestampLayout, ts)
+func dgoTimestampStringToTime(ts string) time.Time {
+	timestamp, err := time.Parse(dgoTimestampLayout, ts)
 	if err != nil {
 		panic(err)
 		//return time.Now() // this is so bad..
@@ -61,113 +61,113 @@ func discordgoTimestampStringToTime(ts string) time.Time {
 	return timestamp
 }
 
-func discordgoUserArrayTODiscordUserArray(users []*discordgo.User) []*User {
+func dgoUsersTODiscordUsers(users []*discordgo.User) []*User {
 	discordUsers := make([]*User, 0, len(users))
 	for i, user := range users {
-		discordUsers[i] = NewUserFromDiscordgo(user)
+		discordUsers[i] = NewUserFromDgo(user)
 	}
 
 	return discordUsers
 }
 
-func discordgoRolesToDiscordRoles(rs []*discordgo.Role) []*Role {
+func dgoRolesToDiscordRoles(rs []*discordgo.Role) []*Role {
 	roles := make([]*Role, 0, len(rs))
 	for i, r := range rs {
-		roles[i] = NewRoleFromDiscordgo(r)
+		roles[i] = NewRoleFromDgo(r)
 	}
 
 	return roles
 }
 
-func discordgoEmojisToDiscordEmojis(es []*discordgo.Emoji) []*Emoji {
+func dgoEmojisToDiscordEmojis(es []*discordgo.Emoji) []*Emoji {
 	emojis := make([]*Emoji, 0, len(es))
 	for i, e := range es {
-		emojis[i] = NewEmojiFromDiscordgo(e)
+		emojis[i] = NewEmojiFromDgo(e)
 	}
 
 	return emojis
 }
 
-func discordgoGuildMembersToDiscordGuildMembers(ms []*discordgo.Member) []*GuildMember {
+func dgoGuildMembersToDiscordGuildMembers(ms []*discordgo.Member) []*GuildMember {
 	guildMembers := make([]*GuildMember, 0, len(ms))
 	for i, m := range ms {
-		guildMembers[i] = NewGuildMemberFromDiscordgo(m)
+		guildMembers[i] = NewGuildMemberFromDgo(m)
 	}
 
 	return guildMembers
 }
 
-func discordgoPresencesToDiscordPresences(ps []*discordgo.Presence) []*Presence {
+func dgoPresencesToDiscordPresences(ps []*discordgo.Presence) []*Presence {
 	presences := make([]*Presence, 0, len(ps))
 	for i, p := range ps {
-		presences[i] = NewPresenceFromDiscordgo(p)
+		presences[i] = NewPresenceFromDgo(p)
 	}
 
 	return presences
 }
 
-func discordgoChannelsToDiscordChannels(cs []*discordgo.Channel) []*Channel {
+func dgoChannelsToDiscordChannels(cs []*discordgo.Channel) []*Channel {
 	channels := make([]*Channel, 0, len(cs))
 	for i, c := range cs {
-		channels[i] = NewChannelFromDiscordgo(c)
+		channels[i] = NewChannelFromDgo(c)
 	}
 
 	return channels
 }
 
-func discordgoVoiceStatesToDiscordVoiceStates(vss []*discordgo.VoiceState) []*VoiceState {
+func dgoVoiceStatesToDiscordVoiceStates(vss []*discordgo.VoiceState) []*VoiceState {
 	voiceStates := make([]*VoiceState, 0, len(vss))
 	for i, vs := range vss {
-		voiceStates[i] = NewVoiceStateFromDiscordgo(vs)
+		voiceStates[i] = NewVoiceStateFromDgo(vs)
 	}
 
 	return voiceStates
 }
 
-func discordgoMessagesToDiscordMessages(ms []*discordgo.Message) []*Message {
+func dgoMessagesToDiscordMessages(ms []*discordgo.Message) []*Message {
 	messages := make([]*Message, 0, len(ms))
 	for i, m := range ms {
-		messages[i] = NewMessageFromDiscordgo(m)
+		messages[i] = NewMessageFromDgo(m)
 	}
 
 	return messages
 }
 
-func discordgoPermissionOverwritesToDiscordPermissionOverwrites(pms []*discordgo.PermissionOverwrite) []*PermissionOverwrite {
+func dgoPermissionOverwritesToDiscordPermissionOverwrites(pms []*discordgo.PermissionOverwrite) []*PermissionOverwrite {
 	permissionOverwrites := make([]*PermissionOverwrite, 0, len(pms))
 	for i, pm := range pms {
-		permissionOverwrites[i] = NewPermissionOverwriteFromDiscordgo(pm)
+		permissionOverwrites[i] = NewPermissionOverwriteFromDgo(pm)
 	}
 
 	return permissionOverwrites
 }
 
-func discordgoCopyTodiscordStruct(discordgoStruct interface{}, discordStruct interface{}) {
+func dgoCopyTodiscordStruct(discordgoStruct interface{}, discordStruct interface{}) {
 	// TODO use reflection to copy over values with similar type and json tag.
 }
 
-func discordgoMessageTypeToUint8(t discordgo.MessageType) uint8 {
-	return uint8(t)
+func dgoMessageTypeToUint(t discordgo.MessageType) uint {
+	return uint(t)
 }
 
-func discordgoVerificationLevelToUint8(vl discordgo.VerificationLevel) uint8 {
-	return uint8(vl)
+func dgoVerificationLevelToUint(vl discordgo.VerificationLevel) uint {
+	return uint(vl)
 }
 
-func discordgoChannelTypeToUint8(ct discordgo.ChannelType) uint8 {
-	return uint8(ct)
+func dgoChannelTypeToUint(ct discordgo.ChannelType) uint {
+	return uint(ct)
 }
 
-func discordgoStatusToString(s discordgo.Status) string {
+func dgoStatusToString(s discordgo.Status) string {
 	return string(s)
 }
 
 // Struct converters
 //
 
-func NewUserFromDiscordgo(user *discordgo.User) *User {
+func NewUserFromDgo(user *discordgo.User) *User {
 	return &User{
-		ID:            discordgoIDStringToUint64(user.ID),
+		ID:            dgoIDStringToUint64(user.ID),
 		Email:         user.Email,
 		Username:      user.Username,
 		Avatar:        user.Avatar,
@@ -179,13 +179,13 @@ func NewUserFromDiscordgo(user *discordgo.User) *User {
 	}
 }
 
-func NewEmbedFromDiscordgoEmbed(e *discordgo.MessageEmbed) *Embed {
+func NewEmbedFromDgoEmbed(e *discordgo.MessageEmbed) *Embed {
 	return &Embed{
 		Title:       e.Title,
 		Type:        e.Type,
 		Description: e.Description,
 		URL:         e.URL,
-		Timestamp:   discordgoTimestampStringToTime(e.Timestamp),
+		Timestamp:   dgoTimestampStringToTime(e.Timestamp),
 		Color:       e.Color,
 		// Footer: NewEmbedFooterFromDiscordgo(e.Footer),
 		// Image: NewEmbedImageFromDiscordgo(e.Image),
@@ -193,62 +193,62 @@ func NewEmbedFromDiscordgoEmbed(e *discordgo.MessageEmbed) *Embed {
 		// Video: NewEmbedVideoFromDiscordgo(e.Video),
 		// Provider: NewEmbedProviderFromDiscordgo(e.Provider),
 		// Author: NewEmbedAuthorFromDiscordgo(e.Author),
-		// Fields: discordgoFieldArrayToDiscordEmbedFieldArray(e.Fields),
+		// Fields: dgoFieldArrayToDiscordEmbedFieldArray(e.Fields),
 	}
 	// TODO
 }
 
-func NewGuildFromDiscordgo(g *discordgo.Guild) *Guild {
+func NewGuildFromDgo(g *discordgo.Guild) *Guild {
 	return &Guild{
-		ID:                discordgoIDStringToUint64(g.ID),
+		ID:                dgoIDStringToUint64(g.ID),
 		Name:              g.Name,
 		Icon:              g.Icon,
 		Region:            g.Region,
-		AfkChannelID:      discordgoIDStringToUint64(g.AfkChannelID),
-		EmbedChannelID:    discordgoIDStringToUint64(g.EmbedChannelID),
-		OwnerID:           discordgoIDStringToUint64(g.OwnerID),
-		JoinedAt:          discordgoTimestampToTime(g.JoinedAt),
+		AfkChannelID:      dgoIDStringToUint64(g.AfkChannelID),
+		EmbedChannelID:    dgoIDStringToUint64(g.EmbedChannelID),
+		OwnerID:           dgoIDStringToUint64(g.OwnerID),
+		JoinedAt:          dgoTimestampToTime(g.JoinedAt),
 		Splash:            g.Splash,
 		AfkTimeout:        uint(g.AfkTimeout),
 		MemberCount:       uint(g.MemberCount),
-		VerificationLevel: discordgoVerificationLevelToUint8(g.VerificationLevel),
+		VerificationLevel: dgoVerificationLevelToUint(g.VerificationLevel),
 		EmbedEnabled:      g.EmbedEnabled,
 		Large:             g.Large,
 		DefaultMessageNotifications: g.DefaultMessageNotifications, // TODO: review type
-		Roles:       discordgoRolesToDiscordRoles(g.Roles),
-		Emojis:      discordgoEmojisToDiscordEmojis(g.Emojis),
-		Members:     discordgoGuildMembersToDiscordGuildMembers(g.Members),
-		Presences:   discordgoPresencesToDiscordPresences(g.Presences),
-		Channels:    discordgoChannelsToDiscordChannels(g.Channels),
-		VoiceStates: discordgoVoiceStatesToDiscordVoiceStates(g.VoiceStates),
+		Roles:       dgoRolesToDiscordRoles(g.Roles),
+		Emojis:      dgoEmojisToDiscordEmojis(g.Emojis),
+		Members:     dgoGuildMembersToDiscordGuildMembers(g.Members),
+		Presences:   dgoPresencesToDiscordPresences(g.Presences),
+		Channels:    dgoChannelsToDiscordChannels(g.Channels),
+		VoiceStates: dgoVoiceStatesToDiscordVoiceStates(g.VoiceStates),
 		Unavailable: g.Unavailable,
 	}
 }
 
-func NewMessageFromDiscordgo(msg *discordgo.Message) *Message {
+func NewMessageFromDgo(msg *discordgo.Message) *Message {
 	return &Message{
-		ID:              discordgoIDStringToUint64(msg.ID),
-		ChannelID:       discordgoIDStringToUint64(msg.ChannelID),
+		ID:              dgoIDStringToUint64(msg.ID),
+		ChannelID:       dgoIDStringToUint64(msg.ChannelID),
 		Content:         msg.Content,
-		Timestamp:       discordgoTimestampToTime(msg.Timestamp),
+		Timestamp:       dgoTimestampToTime(msg.Timestamp),
 		Tts:             msg.Tts,
 		MentionEveryone: msg.MentionEveryone,
-		Mentions:        discordgoUserArrayTODiscordUserArray(msg.Mentions),
-		MentionRoles:    discordgoIDStringArrayToUint64Array(msg.MentionRoles),
-		Attachments:     discordgoAttachmentArrayToDiscordAttachmentArray(msg.Attachments),
-		// Embeds: discordgoMessageEmbedsToDiscordEmbeds(msg.Embeds),
-		// Reactions: discordgoReactionsToDiscordReactions(msg.Reactions),
-		// Nonce: discordgoIDStringToUint64(msg.Nonce),
+		Mentions:        dgoUsersTODiscordUsers(msg.Mentions),
+		MentionRoles:    dgoIDStringsToUint64s(msg.MentionRoles),
+		Attachments:     dgoAttachmentsToDiscordAttachments(msg.Attachments),
+		// Embeds: dgoMessageEmbedsToDiscordEmbeds(msg.Embeds),
+		// Reactions: dgoReactionsToDiscordReactions(msg.Reactions),
+		// Nonce: dgoIDStringToUint64(msg.Nonce),
 		// Pinned: msg.Pinned, // not implemented by discordgo..
-		// WebhookID: discordgoIDStringToUint64(msg.WebhookID), // Not implemented by discordgo...
-		Type: discordgoMessageTypeToUint8(msg.Type),
+		// WebhookID: dgoIDStringToUint64(msg.WebhookID), // Not implemented by discordgo...
+		Type: dgoMessageTypeToUint(msg.Type),
 	}
 	// TODO
 }
 
-func NewRoleFromDiscordgo(r *discordgo.Role) *Role {
+func NewRoleFromDgo(r *discordgo.Role) *Role {
 	return &Role{
-		ID:          discordgoIDStringToUint64(r.ID),
+		ID:          dgoIDStringToUint64(r.ID),
 		Name:        r.Name,
 		Managed:     r.Managed,
 		Mentionable: r.Mentionable,
@@ -259,62 +259,62 @@ func NewRoleFromDiscordgo(r *discordgo.Role) *Role {
 	}
 }
 
-func NewEmojiFromDiscordgo(e *discordgo.Emoji) *Emoji {
+func NewEmojiFromDgo(e *discordgo.Emoji) *Emoji {
 	return &Emoji{
-		ID:            discordgoIDStringToUint64(e.ID),
+		ID:            dgoIDStringToUint64(e.ID),
 		Name:          e.Name,
-		Roles:         discordgoIDStringArrayToUint64Array(e.Roles),
+		Roles:         dgoIDStringsToUint64s(e.Roles),
 		RequireColons: e.RequireColons,
 		Managed:       e.Managed,
 		// User: NewUserFromDiscordgo(e.User), // Not implemented by discordgo
 	}
 }
 
-func NewGuildMemberFromDiscordgo(m *discordgo.Member) *GuildMember {
+func NewGuildMemberFromDgo(m *discordgo.Member) *GuildMember {
 	return &GuildMember{
-		GuildID:  discordgoIDStringToUint64(m.GuildID),
-		JoinedAt: discordgoTimestampStringToTime(m.JoinedAt),
+		GuildID:  dgoIDStringToUint64(m.GuildID),
+		JoinedAt: dgoTimestampStringToTime(m.JoinedAt),
 		Nick:     m.Nick,
 		Deaf:     m.Deaf,
 		Mute:     m.Mute,
-		User:     NewUserFromDiscordgo(m.User),
-		Roles:    discordgoIDStringArrayToUint64Array(m.Roles),
+		User:     NewUserFromDgo(m.User),
+		Roles:    dgoIDStringsToUint64s(m.Roles),
 	}
 }
 
-func NewPresenceFromDiscordgo(p *discordgo.Presence) *Presence {
+func NewPresenceFromDgo(p *discordgo.Presence) *Presence {
 	return &Presence{
-		User:  NewUserFromDiscordgo(p.User),
-		Roles: discordgoIDStringArrayToUint64Array(p.Roles),
+		User:  NewUserFromDgo(p.User),
+		Roles: dgoIDStringsToUint64s(p.Roles),
 		// Game: NewActivityFromDiscordgo(p.Activity), // not implemented by discordgo...
-		// GuildID: discordgoIDStringToUint64(p.GuildID), // not implemented by discordgo..
-		Status: discordgoStatusToString(p.Status),
+		// GuildID: dgoIDStringToUint64(p.GuildID), // not implemented by discordgo..
+		Status: dgoStatusToString(p.Status),
 	}
 }
 
-func NewChannelFromDiscordgo(c *discordgo.Channel) *Channel {
+func NewChannelFromDgo(c *discordgo.Channel) *Channel {
 	return &Channel{
-		ID:                   discordgoIDStringToUint64(c.ID),
-		GuildID:              discordgoIDStringToUint64(c.GuildID),
+		ID:                   dgoIDStringToUint64(c.ID),
+		GuildID:              dgoIDStringToUint64(c.GuildID),
 		Name:                 c.Name,
 		Topic:                c.Topic,
-		Type:                 discordgoChannelTypeToUint8(c.Type),
-		LastMessageID:        discordgoIDStringToUint64(c.ID),
+		Type:                 dgoChannelTypeToUint(c.Type),
+		LastMessageID:        dgoIDStringToUint64(c.ID),
 		NSFW:                 c.NSFW,
 		Position:             uint(c.Position),
 		Bitrate:              c.Bitrate,
-		Recipients:           discordgoUserArrayTODiscordUserArray(c.Recipients),
-		Messages:             discordgoMessagesToDiscordMessages(c.Messages),
-		PermissionOverwrites: discordgoPermissionOverwritesToDiscordPermissionOverwrites(c.PermissionOverwrites),
+		Recipients:           dgoUsersTODiscordUsers(c.Recipients),
+		Messages:             dgoMessagesToDiscordMessages(c.Messages),
+		PermissionOverwrites: dgoPermissionOverwritesToDiscordPermissionOverwrites(c.PermissionOverwrites),
 	}
 }
 
-func NewVoiceStateFromDiscordgo(vs *discordgo.VoiceState) *VoiceState {
+func NewVoiceStateFromDgo(vs *discordgo.VoiceState) *VoiceState {
 	return &VoiceState{
-		UserID:    discordgoIDStringToUint64(vs.UserID),
-		SessionID: discordgoIDStringToUint64(vs.SessionID),
-		ChannelID: discordgoIDStringToUint64(vs.ChannelID),
-		GuildID:   discordgoIDStringToUint64(vs.GuildID),
+		UserID:    dgoIDStringToUint64(vs.UserID),
+		SessionID: dgoIDStringToUint64(vs.SessionID),
+		ChannelID: dgoIDStringToUint64(vs.ChannelID),
+		GuildID:   dgoIDStringToUint64(vs.GuildID),
 		Suppress:  vs.Suppress,
 		SelfMute:  vs.SelfMute,
 		SelfDeaf:  vs.SelfDeaf,
@@ -323,11 +323,23 @@ func NewVoiceStateFromDiscordgo(vs *discordgo.VoiceState) *VoiceState {
 	}
 }
 
-func NewPermissionOverwriteFromDiscordgo(pm *discordgo.PermissionOverwrite) *PermissionOverwrite {
+func NewPermissionOverwriteFromDgo(pm *discordgo.PermissionOverwrite) *PermissionOverwrite {
 	return &PermissionOverwrite{
-		ID:    discordgoIDStringToUint64(pm.ID),
+		ID:    dgoIDStringToUint64(pm.ID),
 		Type:  pm.Type,
 		Deny:  pm.Deny,
 		Allow: pm.Allow,
+	}
+}
+
+func NewAttachmentFromDgo(a *discordgo.MessageAttachment) *Attachment {
+	return &Attachment{
+		ID:       dgoIDStringToUint64(a.ID),
+		Filename: a.Filename,
+		Size:     uint(a.Size),
+		URL:      a.URL,
+		ProxyURL: a.ProxyURL,
+		Height:   uint(a.Height),
+		Width:    uint(a.Width),
 	}
 }

--- a/discord/discordgoconv.go
+++ b/discord/discordgoconv.go
@@ -44,8 +44,8 @@ func discordgoAttachmentArrayToDiscordAttachmentArray(as []*discordgo.MessageAtt
 	return attachments
 }
 
-func discordgoTimestampToTime(ts string) time.Time {
-	timestamp, err := time.Parse(discordgoTimestampLayout, ts)
+func discordgoTimestampToTime(ts discordgo.Timestamp) time.Time {
+	timestamp, err := time.Parse(discordgoTimestampLayout, string(ts))
 	if err != nil {
 		panic(err)
 		//return time.Now() // this is so bad..

--- a/discord/discordgoconv.go
+++ b/discord/discordgoconv.go
@@ -324,5 +324,10 @@ func NewVoiceStateFromDiscordgo(vs *discordgo.VoiceState) *VoiceState {
 }
 
 func NewPermissionOverwriteFromDiscordgo(pm *discordgo.PermissionOverwrite) *PermissionOverwrite {
-	return &PermissionOverwrite{}
+	return &PermissionOverwrite{
+		ID:    discordgoIDStringToUint64(pm.ID),
+		Type:  pm.Type,
+		Deny:  pm.Deny,
+		Allow: pm.Allow,
+	}
 }

--- a/discord/discordgoconv.go
+++ b/discord/discordgoconv.go
@@ -9,6 +9,9 @@ import (
 
 const discordgoTimestampLayout string = "2016-08-06T17:20:33.803-0400"
 
+// Small purpose specific functionality
+//
+
 func discordgoIDStringToUint64(id string) uint64 {
 	if id == "" {
 		return 0
@@ -45,7 +48,11 @@ func discordgoAttachmentArrayToDiscordAttachmentArray(as []*discordgo.MessageAtt
 }
 
 func discordgoTimestampToTime(ts discordgo.Timestamp) time.Time {
-	timestamp, err := time.Parse(discordgoTimestampLayout, string(ts))
+	return discordgoTimestampStringToTime(string(ts))
+}
+
+func discordgoTimestampStringToTime(ts string) time.Time {
+	timestamp, err := time.Parse(discordgoTimestampLayout, ts)
 	if err != nil {
 		panic(err)
 		//return time.Now() // this is so bad..
@@ -63,6 +70,182 @@ func discordgoUserArrayTODiscordUserArray(users []*discordgo.User) []*User {
 	return discordUsers
 }
 
+func discordgoRolesToDiscordRoles(rs []*discordgo.Role) []*Role {
+	roles := make([]*Role, 0, len(rs))
+	for i, r := range rs {
+		roles[i] = NewRoleFromDiscordgo(r)
+	}
+
+	return roles
+}
+
+func discordgoEmojisToDiscordEmojis(es []*discordgo.Emoji) []*Emoji {
+	emojis := make([]*Emoji, 0, len(es))
+	for i, e := range es {
+		emojis[i] = NewEmojiFromDiscordgo(e)
+	}
+
+	return emojis
+}
+
+func discordgoGuildMembersToDiscordGuildMembers(ms []*discordgo.Member) []*GuildMember {
+	guildMembers := make([]*GuildMember, 0, len(ms))
+	for i, m := range ms {
+		guildMembers[i] = NewGuildMemberFromDiscordgo(m)
+	}
+
+	return guildMembers
+}
+
+func discordgoPresencesToDiscordPresences(ps []*discordgo.Presence) []*Presence {
+	presences := make([]*Presence, 0, len(ps))
+	for i, p := range ps {
+		presences[i] = NewPresenceFromDiscordgo(p)
+	}
+
+	return presences
+}
+
+func discordgoChannelsToDiscordChannels(cs []*discordgo.Channel) []*Channel {
+	channels := make([]*Channel, 0, len(cs))
+	for i, c := range cs {
+		channels[i] = NewChannelFromDiscordgo(c)
+	}
+
+	return channels
+}
+
+func discordgoVoiceStatesToDiscordVoiceStates(vss []*discordgo.VoiceState) []*VoiceState {
+	voiceStates := make([]*VoiceState, 0, len(vss))
+	for i, vs := range vss {
+		voiceStates[i] = NewVoiceStateFromDiscordgo(vs)
+	}
+
+	return voiceStates
+}
+
 func discordgoCopyTodiscordStruct(discordgoStruct interface{}, discordStruct interface{}) {
 	// TODO use reflection to copy over values with similar type and json tag.
+}
+
+func discordgoMessageTypeToUint8(t discordgo.MessageType) uint8 {
+	return uint8(t)
+}
+
+func discordgoVerificationLevelToUint8(vl discordgo.VerificationLevel) uint8 {
+	return uint8(vl)
+}
+
+// Struct converters
+//
+
+func NewUserFromDiscordgo(user *discordgo.User) *User {
+	return &User{
+		ID:            discordgoIDStringToUint64(user.ID),
+		Email:         user.Email,
+		Username:      user.Username,
+		Avatar:        user.Avatar,
+		Discriminator: user.Discriminator,
+		Token:         user.Token,
+		Verified:      user.Verified,
+		MFAEnabled:    user.MFAEnabled,
+		Bot:           user.Bot,
+	}
+}
+
+func NewEmbedFromDiscordgoEmbed(e *discordgo.MessageEmbed) *Embed {
+	return &Embed{
+		Title:       e.Title,
+		Type:        e.Type,
+		Description: e.Description,
+		URL:         e.URL,
+		Timestamp:   discordgoTimestampStringToTime(e.Timestamp),
+		Color:       e.Color,
+		// Footer: NewEmbedFooterFromDiscordgo(e.Footer),
+		// Image: NewEmbedImageFromDiscordgo(e.Image),
+		// Thumbnail: NewEmbedThumbnailFromDiscordgo(e.Thumbnail),
+		// Video: NewEmbedVideoFromDiscordgo(e.Video),
+		// Provider: NewEmbedProviderFromDiscordgo(e.Provider),
+		// Author: NewEmbedAuthorFromDiscordgo(e.Author),
+		// Fields: discordgoFieldArrayToDiscordEmbedFieldArray(e.Fields),
+	}
+	// TODO
+}
+
+func NewGuildFromDiscordgo(g *discordgo.Guild) *Guild {
+	return &Guild{
+		ID:                discordgoIDStringToUint64(g.ID),
+		Name:              g.Name,
+		Icon:              g.Icon,
+		Region:            g.Region,
+		AfkChannelID:      discordgoIDStringToUint64(g.AfkChannelID),
+		EmbedChannelID:    discordgoIDStringToUint64(g.EmbedChannelID),
+		OwnerID:           discordgoIDStringToUint64(g.OwnerID),
+		JoinedAt:          discordgoTimestampToTime(g.JoinedAt),
+		Splash:            g.Splash,
+		AfkTimeout:        uint(g.AfkTimeout),
+		MemberCount:       uint(g.MemberCount),
+		VerificationLevel: discordgoVerificationLevelToUint8(g.VerificationLevel),
+		EmbedEnabled:      g.EmbedEnabled,
+		Large:             g.Large,
+		DefaultMessageNotifications: g.DefaultMessageNotifications, // TODO: review type
+		Roles:       discordgoRolesToDiscordRoles(g.Roles),
+		Emojis:      discordgoEmojisToDiscordEmojis(g.Emojis),
+		Members:     discordgoGuildMembersToDiscordGuildMembers(g.Members),
+		Presences:   discordgoPresencesToDiscordPresences(g.Presences),
+		Channels:    discordgoChannelsToDiscordChannels(g.Channels),
+		VoiceStates: discordgoVoiceStatesToDiscordVoiceStates(g.VoiceStates),
+		Unavailable: g.Unavailable,
+	}
+}
+
+func NewMessageFromDiscordgo(msg *discordgo.Message) *Message {
+	return &Message{
+		ID:              discordgoIDStringToUint64(msg.ID),
+		ChannelID:       discordgoIDStringToUint64(msg.ChannelID),
+		Content:         msg.Content,
+		Timestamp:       discordgoTimestampToTime(msg.Timestamp),
+		Tts:             msg.Tts,
+		MentionEveryone: msg.MentionEveryone,
+		Mentions:        discordgoUserArrayTODiscordUserArray(msg.Mentions),
+		MentionRoles:    discordgoIDStringArrayToUint64Array(msg.MentionRoles),
+		Attachments:     discordgoAttachmentArrayToDiscordAttachmentArray(msg.Attachments),
+		// Embeds: discordgoMessageEmbedsToDiscordEmbeds(msg.Embeds),
+		// Reactions: discordgoReactionsToDiscordReactions(msg.Reactions),
+		// Nonce: discordgoIDStringToUint64(msg.Nonce),
+		// Pinned: msg.Pinned, // not implemented by discordgo..
+		// WebhookID: discordgoIDStringToUint64(msg.WebhookID), // Not implemented by discordgo...
+		Type: discordgoMessageTypeToUint8(msg.Type),
+	}
+	// TODO
+}
+
+func NewRoleFromDiscordgo(r *discordgo.Role) *Role {
+	return &Role{}
+	// TODO
+}
+
+func NewEmojiFromDiscordgo(e *discordgo.Emoji) *Emoji {
+	return &Emoji{}
+	// TODO
+}
+
+func NewGuildMemberFromDiscordgo(m *discordgo.Member) *GuildMember {
+	return &GuildMember{}
+	// TODO
+}
+
+func NewPresenceFromDiscordgo(p *discordgo.Presence) *Presence {
+	return &Presence{}
+	// TODO
+}
+
+func NewChannelFromDiscordgo(c *discordgo.Channel) *Channel {
+	return &Channel{}
+	// TODO
+}
+
+func NewVoiceStateFromDiscordgo(vs *discordgo.VoiceState) *VoiceState {
+	return &VoiceState{}
+	// TODO
 }

--- a/discord/discordgoconv.go
+++ b/discord/discordgoconv.go
@@ -231,11 +231,18 @@ func NewRoleFromDiscordgo(r *discordgo.Role) *Role {
 		Position:    r.Position,
 		Permissions: uint64(r.Permissions),
 	}
-	// TODO
 }
 
 func NewEmojiFromDiscordgo(e *discordgo.Emoji) *Emoji {
-	return &Emoji{}
+	return &Emoji{
+		ID:            discordgoIDStringToUint64(e.ID),
+		Name:          e.Name,
+		Roles:         discordgoIDStringArrayToUint64Array(e.Roles),
+		RequireColons: e.RequireColons,
+		Managed:       e.Managed,
+		// User: NewUserFromDiscordgo(e.User), // Not implemented by discordgo
+
+	}
 	// TODO
 }
 

--- a/discord/discordgoconv.go
+++ b/discord/discordgoconv.go
@@ -241,14 +241,19 @@ func NewEmojiFromDiscordgo(e *discordgo.Emoji) *Emoji {
 		RequireColons: e.RequireColons,
 		Managed:       e.Managed,
 		// User: NewUserFromDiscordgo(e.User), // Not implemented by discordgo
-
 	}
-	// TODO
 }
 
 func NewGuildMemberFromDiscordgo(m *discordgo.Member) *GuildMember {
-	return &GuildMember{}
-	// TODO
+	return &GuildMember{
+		GuildID:  discordgoIDStringToUint64(m.GuildID),
+		JoinedAt: discordgoTimestampStringToTime(m.JoinedAt),
+		Nick:     m.Nick,
+		Deaf:     m.Deaf,
+		Mute:     m.Mute,
+		User:     NewUserFromDiscordgo(m.User),
+		Roles:    discordgoIDStringArrayToUint64Array(m.Roles),
+	}
 }
 
 func NewPresenceFromDiscordgo(p *discordgo.Presence) *Presence {

--- a/discord/discordgoconv.go
+++ b/discord/discordgoconv.go
@@ -22,6 +22,15 @@ func discordgoIDStringToUint64(id string) uint64 {
 	return u
 }
 
+func discordgoIDStringArrayToUint64Array(ids []string) []uint64 {
+	newIDS := make([]uint64, 0, len(ids))
+	for i, id := range ids {
+		newIDS[i] = discordgoIDStringToUint64(id)
+	}
+
+	return newIDS
+}
+
 func uint64ToString(id uint64) string {
 	return strconv.FormatUint(id, 10)
 }

--- a/discord/discordgoconv.go
+++ b/discord/discordgoconv.go
@@ -124,6 +124,24 @@ func discordgoVoiceStatesToDiscordVoiceStates(vss []*discordgo.VoiceState) []*Vo
 	return voiceStates
 }
 
+func discordgoMessagesToDiscordMessages(ms []*discordgo.Message) []*Message {
+	messages := make([]*Message, 0, len(ms))
+	for i, m := range ms {
+		messages[i] = NewMessageFromDiscordgo(m)
+	}
+
+	return messages
+}
+
+func discordgoPermissionOverwritesToDiscordPermissionOverwrites(pms []*discordgo.PermissionOverwrite) []*PermissionOverwrite {
+	permissionOverwrites := make([]*PermissionOverwrite, 0, len(pms))
+	for i, pm := range pms {
+		permissionOverwrites[i] = NewPermissionOverwriteFromDiscordgo(pm)
+	}
+
+	return permissionOverwrites
+}
+
 func discordgoCopyTodiscordStruct(discordgoStruct interface{}, discordStruct interface{}) {
 	// TODO use reflection to copy over values with similar type and json tag.
 }
@@ -134,6 +152,10 @@ func discordgoMessageTypeToUint8(t discordgo.MessageType) uint8 {
 
 func discordgoVerificationLevelToUint8(vl discordgo.VerificationLevel) uint8 {
 	return uint8(vl)
+}
+
+func discordgoChannelTypeToUint8(ct discordgo.ChannelType) uint8 {
+	return uint8(ct)
 }
 
 func discordgoStatusToString(s discordgo.Status) string {
@@ -271,8 +293,20 @@ func NewPresenceFromDiscordgo(p *discordgo.Presence) *Presence {
 }
 
 func NewChannelFromDiscordgo(c *discordgo.Channel) *Channel {
-	return &Channel{}
-	// TODO
+	return &Channel{
+		ID:                   discordgoIDStringToUint64(c.ID),
+		GuildID:              discordgoIDStringToUint64(c.GuildID),
+		Name:                 c.Name,
+		Topic:                c.Topic,
+		Type:                 discordgoChannelTypeToUint8(c.Type),
+		LastMessageID:        discordgoIDStringToUint64(c.ID),
+		NSFW:                 c.NSFW,
+		Position:             uint(c.Position),
+		Bitrate:              c.Bitrate,
+		Recipients:           discordgoUserArrayTODiscordUserArray(c.Recipients),
+		Messages:             discordgoMessagesToDiscordMessages(c.Messages),
+		PermissionOverwrites: discordgoPermissionOverwritesToDiscordPermissionOverwrites(c.PermissionOverwrites),
+	}
 }
 
 func NewVoiceStateFromDiscordgo(vs *discordgo.VoiceState) *VoiceState {
@@ -287,4 +321,8 @@ func NewVoiceStateFromDiscordgo(vs *discordgo.VoiceState) *VoiceState {
 		Mute:      vs.Mute,
 		Deaf:      vs.Deaf,
 	}
+}
+
+func NewPermissionOverwriteFromDiscordgo(pm *discordgo.PermissionOverwrite) *PermissionOverwrite {
+	return &PermissionOverwrite{}
 }

--- a/discord/discordgoconv.go
+++ b/discord/discordgoconv.go
@@ -276,6 +276,15 @@ func NewChannelFromDiscordgo(c *discordgo.Channel) *Channel {
 }
 
 func NewVoiceStateFromDiscordgo(vs *discordgo.VoiceState) *VoiceState {
-	return &VoiceState{}
-	// TODO
+	return &VoiceState{
+		UserID:    discordgoIDStringToUint64(vs.UserID),
+		SessionID: discordgoIDStringToUint64(vs.SessionID),
+		ChannelID: discordgoIDStringToUint64(vs.ChannelID),
+		GuildID:   discordgoIDStringToUint64(vs.GuildID),
+		Suppress:  vs.Suppress,
+		SelfMute:  vs.SelfMute,
+		SelfDeaf:  vs.SelfDeaf,
+		Mute:      vs.Mute,
+		Deaf:      vs.Deaf,
+	}
 }

--- a/discord/discordgoconv.go
+++ b/discord/discordgoconv.go
@@ -35,6 +35,15 @@ func uint64ToString(id uint64) string {
 	return strconv.FormatUint(id, 10)
 }
 
+func discordgoAttachmentArrayToDiscordAttachmentArray(as []*discordgo.MessageAttachment) []*Attachment {
+	attachments := make([]*Attachment, 0, len(as))
+	for i, a := range as {
+		attachments[i] = NewAttachmentFromDiscordgo(a)
+	}
+
+	return attachments
+}
+
 func discordgoTimestampToTime(ts string) time.Time {
 	timestamp, err := time.Parse(discordgoTimestampLayout, ts)
 	if err != nil {

--- a/discord/embed.go
+++ b/discord/embed.go
@@ -1,6 +1,8 @@
 package discord
 
-import "time"
+import (
+	"time"
+)
 
 type Embed struct {
 	Title       string          `json:"title"`       // title of embed

--- a/discord/guild.go
+++ b/discord/guild.go
@@ -16,7 +16,7 @@ type Guild struct {
 	Splash                      string         `json:"splash"`
 	AfkTimeout                  uint           `json:"afk_timeout"`
 	MemberCount                 uint           `json:"member_count"`
-	VerificationLevel           uint8          `json:"verification_level"`
+	VerificationLevel           uint           `json:"verification_level"`
 	EmbedEnabled                bool           `json:"embed_enabled"`
 	Large                       bool           `json:"large"` // ??
 	DefaultMessageNotifications int            `json:"default_message_notifications"`

--- a/discord/guild.go
+++ b/discord/guild.go
@@ -2,8 +2,6 @@ package discord
 
 import (
 	"time"
-
-	"gopkg.in/bwmarrin/Discordgo.v0"
 )
 
 type Guild struct {
@@ -16,9 +14,9 @@ type Guild struct {
 	OwnerID                     uint64         `json:"owner_id"`
 	JoinedAt                    time.Time      `json:"joined_at"`
 	Splash                      string         `json:"splash"`
-	AfkTimeout                  int            `json:"afk_timeout"`
+	AfkTimeout                  uint           `json:"afk_timeout"`
 	MemberCount                 uint           `json:"member_count"`
-	VerificationLevel           int            `json:"verification_level"`
+	VerificationLevel           uint8          `json:"verification_level"`
 	EmbedEnabled                bool           `json:"embed_enabled"`
 	Large                       bool           `json:"large"` // ??
 	DefaultMessageNotifications int            `json:"default_message_notifications"`
@@ -29,10 +27,4 @@ type Guild struct {
 	Channels                    []*Channel     `json:"channels"`
 	VoiceStates                 []*VoiceState  `json:"voice_states"`
 	Unavailable                 bool           `json:"unavailable"`
-}
-
-func NewGuildFromDiscordgo(guild *discordgo.Guild) *Guild {
-	return &Guild{
-		ID: discordIDStringToUint64(guild.ID),
-	}
 }

--- a/discord/message.go
+++ b/discord/message.go
@@ -7,16 +7,19 @@ import (
 type Message struct {
 	ID              uint64        `json:"id"`
 	ChannelID       uint64        `json:"channel_id"`
+	Author          *User         `json:"author"`
 	Content         string        `json:"content"`
 	Timestamp       time.Time     `json:"timestamp"`
-	EditedTimestamp time.Time     `json:"edited_timestamp"`
-	MentionRoles    []uint64      `json:"mention_roles"`
+	EditedTimestamp time.Time     `json:"edited_timestamp"` // ?
 	Tts             bool          `json:"tts"`
 	MentionEveryone bool          `json:"mention_everyone"`
-	Author          *User         `json:"author"`
+	Mentions        []*User       `json:"mentions"`
+	MentionRoles    []uint64      `json:"mention_roles"`
 	Attachments     []*Attachment `json:"attachments"`
 	Embeds          []*Embed      `json:"embeds"`
-	Mentions        []*User       `json:"mentions"`
-	Reactions       []*Reaction   `json:"reactions"`
+	Reactions       []*Reaction   `json:"reactions"` // ?
+	Nonce           uint64        `json:"nonce"`     // ?, used for validating a message was sent
+	Pinned          bool          `json:"pinned"`
+	WebhookID       uint64        `json:"webhook_id"` // ?
 	Type            uint8         `json:"type"`
 }

--- a/discord/message.go
+++ b/discord/message.go
@@ -21,5 +21,5 @@ type Message struct {
 	Nonce           uint64        `json:"nonce"`     // ?, used for validating a message was sent
 	Pinned          bool          `json:"pinned"`
 	WebhookID       uint64        `json:"webhook_id"` // ?
-	Type            uint8         `json:"type"`
+	Type            uint          `json:"type"`
 }

--- a/discord/snowflake.go
+++ b/discord/snowflake.go
@@ -1,0 +1,11 @@
+package discord
+
+import "strconv"
+
+// Snowflake is the ID type used by discord
+type Snowflake uint64
+
+// SnowflakeToStr converts a snowflake into a string
+func SnowflakeToStr(id Snowflake) string {
+	return strconv.FormatUint(uint64(id), 10)
+}

--- a/discord/user.go
+++ b/discord/user.go
@@ -2,8 +2,6 @@ package discord
 
 import (
 	"fmt"
-
-	"gopkg.in/bwmarrin/Discordgo.v0"
 )
 
 type User struct {
@@ -20,20 +18,6 @@ type User struct {
 
 func NewUser() *User {
 	return &User{}
-}
-
-func NewUserFromDiscordgo(user *discordgo.User) *User {
-	return &User{
-		ID:            discordgoIDStringToUint64(user.ID),
-		Email:         user.Email,
-		Username:      user.Username,
-		Avatar:        user.Avatar,
-		Discriminator: user.Discriminator,
-		Token:         user.Token,
-		Verified:      user.Verified,
-		MFAEnabled:    user.MFAEnabled,
-		Bot:           user.Bot,
-	}
 }
 
 func (u *User) Mention() string {

--- a/discord/user.go
+++ b/discord/user.go
@@ -1,6 +1,10 @@
 package discord
 
-import "fmt"
+import (
+	"fmt"
+
+	"gopkg.in/bwmarrin/Discordgo.v0"
+)
 
 type User struct {
 	ID            uint64 `json:"id"`
@@ -16,6 +20,20 @@ type User struct {
 
 func NewUser() *User {
 	return &User{}
+}
+
+func NewUserFromDiscordgo(user *discordgo.User) *User {
+	return &User{
+		ID:            discordgoIDStringToUint64(user.ID),
+		Email:         user.Email,
+		Username:      user.Username,
+		Avatar:        user.Avatar,
+		Discriminator: user.Discriminator,
+		Token:         user.Token,
+		Verified:      user.Verified,
+		MFAEnabled:    user.MFAEnabled,
+		Bot:           user.Bot,
+	}
 }
 
 func (u *User) Mention() string {

--- a/handlers.go
+++ b/handlers.go
@@ -56,9 +56,9 @@ func handleMessageCreate(ctx *Context, m *discordgo.MessageCreate) {
 		// verify that user has permission to invoke this command
 		memberPermissions, err := ctx.Bot.Discord.UserChannelPermissions(m.Author.ID, m.ChannelID)
 		permissions := &DiscordPermissions{}
-		permissions.Set(DiscordPermissionFlags(memberPermissions))
+		permissions.Set(uint64(memberPermissions))
 		if err != nil || !cmd.invokableWithPermissions(permissions) {
-			logrus.Info("[unison] User " + m.Author.String() + " tried to invoke unaccessable command: " + cmd.Name + ". User permission: " + permissions.ToStr())
+			logrus.Info("[unison] User " + m.Author.String() + " tried to invoke unaccessable command: " + cmd.Name + ". User permission: " + permissions.String())
 			break //command was found but permission was denied, so just stop looking for another command
 		}
 

--- a/permission.go
+++ b/permission.go
@@ -8,28 +8,28 @@ import (
 
 // DiscordPermissionFlags limits member accessability to discord guilds/channels functionality
 // 	https://discordapp.com/developers/docs/topics/permissions
-type DiscordPermissionFlags uint64
+// type DiscordPermissionFlags uint64
 
 func init() {
 	// make sure the ToStr and other methods
-	if uint64(DiscordPermissionFlags(0x8000040000200001)) != uint64(0x8000040000200001) {
+	if uint64(0x8000040000200001) != uint64(0x8000040000200001) {
 		logrus.Fatal("Did the DiscordPermissionFalgs type change? update ToStr() method.")
 	}
 }
 
 type DiscordPermissions struct {
-	flags DiscordPermissionFlags
+	flags uint64
 }
 
-func NewDiscordPermissionsDiscordgoWrapper(flags int, err error) (*DiscordPermissions, error) {
-	return &DiscordPermissions{flags: DiscordPermissionFlags(flags)}, err
+func NewDiscordPermissionsDiscordgoWrapper(flags uint64, err error) (*DiscordPermissions, error) {
+	return &DiscordPermissions{flags: flags}, err
 }
 
-func (dp *DiscordPermissions) Add(flags DiscordPermissionFlags) {
+func (dp *DiscordPermissions) Add(flags uint64) {
 	dp.flags |= flags
 }
 
-func (dp *DiscordPermissions) Remove(flags DiscordPermissionFlags) {
+func (dp *DiscordPermissions) Remove(flags uint64) {
 	// be sure the flags exist
 	dp.Add(flags)
 
@@ -37,11 +37,11 @@ func (dp *DiscordPermissions) Remove(flags DiscordPermissionFlags) {
 	dp.flags ^= flags
 }
 
-func (dp *DiscordPermissions) Set(flags DiscordPermissionFlags) {
+func (dp *DiscordPermissions) Set(flags uint64) {
 	dp.flags = flags
 }
 
-func (dp *DiscordPermissions) Get() DiscordPermissionFlags {
+func (dp *DiscordPermissions) Get() uint64 {
 	return dp.flags
 }
 
@@ -49,6 +49,6 @@ func (dp *DiscordPermissions) HasRequiredPermissions(permission *DiscordPermissi
 	return (permission.Get() & dp.flags) == dp.flags
 }
 
-func (dp *DiscordPermissions) ToStr() string {
-	return strconv.FormatUint(uint64(dp.flags), 10)
+func (dp *DiscordPermissions) String() string {
+	return strconv.FormatUint(dp.flags, 10)
 }


### PR DESCRIPTION
The most commonly used structs are completed, but the adapters from discordgo to discord subpackage is not complete as discordgo is missing functionality or the more rarely used structs haven't been implemented yet.

A new bot method has been added to be able to send messages to channels without having to convert to a discordgo.Channel and discordgo.Message types.